### PR TITLE
Add auto-confirm defaults for major cryptos

### DIFF
--- a/core/src/main/java/haveno/core/user/AutoConfirmSettings.java
+++ b/core/src/main/java/haveno/core/user/AutoConfirmSettings.java
@@ -44,7 +44,6 @@ public final class AutoConfirmSettings implements PersistablePayload {
 
     @SuppressWarnings("SameParameterValue")
     static Optional<AutoConfirmSettings> getDefault(List<String> serviceAddresses, String currencyCode) {
-        //noinspection SwitchStatementWithTooFewBranches
         switch (currencyCode) {
             case "XMR":
                 return Optional.of(new AutoConfirmSettings(
@@ -53,7 +52,31 @@ public final class AutoConfirmSettings implements PersistablePayload {
                         Coin.COIN.value,
                         serviceAddresses,
                         "XMR"));
+            case "BTC":
+            case "BCH":
+            case "LTC":
+                return Optional.of(new AutoConfirmSettings(
+                        false,
+                        1,
+                        Coin.COIN.value,
+                        serviceAddresses,
+                        currencyCode));
+            case "ETH":
+                return Optional.of(new AutoConfirmSettings(
+                        false,
+                        12,
+                        1_000_000_000_000_000_000L,
+                        serviceAddresses,
+                        "ETH"));
             default:
+                if (currencyCode.endsWith("-ERC20")) {
+                    return Optional.of(new AutoConfirmSettings(
+                            false,
+                            12,
+                            1_000_000_000_000_000_000L,
+                            serviceAddresses,
+                            currencyCode));
+                }
                 log.error("No AutoConfirmSettings supported yet for currency {}", currencyCode);
                 return Optional.empty();
         }

--- a/core/src/main/java/haveno/core/user/Preferences.java
+++ b/core/src/main/java/haveno/core/user/Preferences.java
@@ -323,11 +323,18 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         }
 
         if (prefPayload.getAutoConfirmSettingsList().isEmpty()) {
+            List<AutoConfirmSettings> list = getAutoConfirmSettingsList();
             List<String> defaultXmrTxProofServices = getDefaultXmrTxProofServices();
-            AutoConfirmSettings.getDefault(defaultXmrTxProofServices, "XMR")
-                    .ifPresent(xmrAutoConfirmSettings -> {
-                        getAutoConfirmSettingsList().add(xmrAutoConfirmSettings);
-                    });
+            AutoConfirmSettings.getDefault(defaultXmrTxProofServices, "XMR").ifPresent(list::add);
+            AutoConfirmSettings.getDefault(new ArrayList<>(), "BTC").ifPresent(list::add);
+            AutoConfirmSettings.getDefault(new ArrayList<>(), "BCH").ifPresent(list::add);
+            AutoConfirmSettings.getDefault(new ArrayList<>(), "LTC").ifPresent(list::add);
+            AutoConfirmSettings.getDefault(new ArrayList<>(), "ETH").ifPresent(list::add);
+            CurrencyUtil.getAllSortedCryptoCurrencies().stream()
+                    .map(CryptoCurrency::getCode)
+                    .filter(code -> code.endsWith("-ERC20"))
+                    .forEach(code ->
+                            AutoConfirmSettings.getDefault(new ArrayList<>(), code).ifPresent(list::add));
         }
 
         // enable sounds by default for existing clients (protobuf does not express that new field is unset)

--- a/core/src/main/java/haveno/core/user/PreferencesPayload.java
+++ b/core/src/main/java/haveno/core/user/PreferencesPayload.java
@@ -200,11 +200,15 @@ public final class PreferencesPayload implements PersistableEnvelope {
                 .setSecurityDepositAsPercentForCrypto(securityDepositAsPercentForCrypto)
                 .setBlockNotifyPort(blockNotifyPort)
                 .setTacAcceptedV120(tacAcceptedV120)
-                .setBsqAverageTrimThreshold(bsqAverageTrimThreshold)
-                .addAllAutoConfirmSettings(autoConfirmSettingsList.stream()
-                        .map(autoConfirmSettings -> ((protobuf.AutoConfirmSettings) autoConfirmSettings.toProtoMessage()))
-                        .collect(Collectors.toList()))
-                .setHideNonAccountPaymentMethods(hideNonAccountPaymentMethods)
+                .setBsqAverageTrimThreshold(bsqAverageTrimThreshold);
+
+        if (!autoConfirmSettingsList.isEmpty()) {
+            builder.addAllAutoConfirmSettings(autoConfirmSettingsList.stream()
+                    .map(autoConfirmSettings -> ((protobuf.AutoConfirmSettings) autoConfirmSettings.toProtoMessage()))
+                    .collect(Collectors.toList()));
+        }
+
+        builder.setHideNonAccountPaymentMethods(hideNonAccountPaymentMethods)
                 .setShowOffersMatchingMyAccounts(showOffersMatchingMyAccounts)
                 .setShowPrivateOffers(showPrivateOffers)
                 .setDenyApiTaker(denyApiTaker)


### PR DESCRIPTION
## Summary
- extend `AutoConfirmSettings` with defaults for BTC, BCH, LTC, ETH and ERC20 tokens
- seed preferences with default auto-confirm settings for these currencies
- guard serialization of auto-confirm settings to persist new currencies safely

## Testing
- `./gradlew core:test`


------
https://chatgpt.com/codex/tasks/task_e_689cae6f3e088330b6ec84090b6e10dd