### PR TITLE
feat: add generic auto-confirm key

### DIFF
--- a/core/src/main/java/haveno/core/offer/OfferPayload.java
+++ b/core/src/main/java/haveno/core/offer/OfferPayload.java
@@ -108,9 +108,14 @@ public final class OfferPayload implements ProtectedStoragePayload, ExpirablePay
     // Capability.SIGNED_ACCOUNT_AGE_WITNESS is 11 and Capability.MEDIATION is 12 so if we want to signal that maker
     // of the offer supports both capabilities we add "11, 12" to capabilities.
     public static final String CAPABILITIES = "capabilities";
-    // If maker is seller and has xmrAutoConf enabled it is set to "1" otherwise it is not set
-    public static final String XMR_AUTO_CONF = "xmrAutoConf";
-    public static final String XMR_AUTO_CONF_ENABLED_VALUE = "1";
+    // If maker is seller and has auto-confirm enabled we add an entry
+    // with key "autoConf_<CURRENCY>" and value "1" (AUTO_CONF_ENABLED_VALUE)
+    public static final String AUTO_CONF_PREFIX = "autoConf_";
+    public static final String AUTO_CONF_ENABLED_VALUE = "1";
+
+    public static String getAutoConfKey(String currencyCode) {
+        return AUTO_CONF_PREFIX + currencyCode;
+    }
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/java/haveno/core/offer/OfferUtil.java
+++ b/core/src/main/java/haveno/core/offer/OfferUtil.java
@@ -44,8 +44,6 @@ import static haveno.core.offer.OfferPayload.F2F_EXTRA_INFO;
 import static haveno.core.offer.OfferPayload.PAY_BY_MAIL_EXTRA_INFO;
 import static haveno.core.offer.OfferPayload.PAYPAL_EXTRA_INFO;
 import static haveno.core.offer.OfferPayload.REFERRAL_ID;
-import static haveno.core.offer.OfferPayload.XMR_AUTO_CONF;
-import static haveno.core.offer.OfferPayload.XMR_AUTO_CONF_ENABLED_VALUE;
 
 import haveno.core.payment.AustraliaPayidAccount;
 import haveno.core.payment.CashAppAccount;
@@ -226,11 +224,12 @@ public class OfferUtil {
 
         extraDataMap.put(CAPABILITIES, Capabilities.app.toStringList());
 
-        if (currencyCode.equals("XMR") && direction == OfferDirection.SELL) {
+        if (direction == OfferDirection.SELL) {
             preferences.getAutoConfirmSettingsList().stream()
-                    .filter(e -> e.getCurrencyCode().equals("XMR"))
+                    .filter(e -> e.getCurrencyCode().equals(currencyCode))
                     .filter(AutoConfirmSettings::isEnabled)
-                    .forEach(e -> extraDataMap.put(XMR_AUTO_CONF, XMR_AUTO_CONF_ENABLED_VALUE));
+                    .forEach(e -> extraDataMap.put(OfferPayload.getAutoConfKey(currencyCode),
+                            OfferPayload.AUTO_CONF_ENABLED_VALUE));
         }
 
         return extraDataMap.isEmpty() ? null : extraDataMap;

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -373,7 +373,7 @@ offerbook.timeSinceSigning.tooltip.info.signedAndLifted=This account has been si
 offerbook.timeSinceSigning.tooltip.checkmark.buyXmr=buy XMR from a signed account
 offerbook.timeSinceSigning.tooltip.checkmark.wait=wait a minimum of {0} days
 offerbook.timeSinceSigning.tooltip.learnMore=Learn more
-offerbook.xmrAutoConf=Is auto-confirm enabled
+offerbook.autoConf=Is auto-confirm enabled
 offerbook.buyXmrWith=Buy XMR with:
 offerbook.sellXmrFor=Sell XMR for:
 

--- a/core/src/main/resources/i18n/displayStrings_cs.properties
+++ b/core/src/main/resources/i18n/displayStrings_cs.properties
@@ -374,7 +374,7 @@ offerbook.timeSinceSigning.tooltip.info.signedAndLifted=Tento účet byl podeps�
 offerbook.timeSinceSigning.tooltip.checkmark.buyXmr=nakoupeno XMR od podepsaného účtu
 offerbook.timeSinceSigning.tooltip.checkmark.wait=čekáno alespoň {0} dnů
 offerbook.timeSinceSigning.tooltip.learnMore=Více informací
-offerbook.xmrAutoConf=Je automatické potvrzení povoleno
+offerbook.autoConf=Je automatické potvrzení povoleno
 offerbook.buyXmrWith=Koupit XMR za:
 offerbook.sellXmrFor=Prodat XMR za:
 

--- a/core/src/main/resources/i18n/displayStrings_de.properties
+++ b/core/src/main/resources/i18n/displayStrings_de.properties
@@ -350,7 +350,7 @@ offerbook.timeSinceSigning.info.signer=vom Partner unterzeichnet und kann Partne
 offerbook.timeSinceSigning.info.banned=Konto wurde geblockt
 offerbook.timeSinceSigning.daysSinceSigning={0} Tage
 offerbook.timeSinceSigning.daysSinceSigning.long={0} seit der Unterzeichnung
-offerbook.xmrAutoConf=Automatische Bestätigung aktiviert
+offerbook.autoConf=Automatische Bestätigung aktiviert
 offerbook.buyXmrWith=XMR kaufen mit:
 offerbook.sellXmrFor=XMR verkaufen für:
 

--- a/core/src/main/resources/i18n/displayStrings_es.properties
+++ b/core/src/main/resources/i18n/displayStrings_es.properties
@@ -350,7 +350,7 @@ offerbook.timeSinceSigning.info.signer=firmado por un par y puede firmar cuentas
 offerbook.timeSinceSigning.info.banned=La cuenta fue bloqueada
 offerbook.timeSinceSigning.daysSinceSigning={0} días
 offerbook.timeSinceSigning.daysSinceSigning.long={0} desde el firmado
-offerbook.xmrAutoConf=¿Está habilitada la confirmación automática?
+offerbook.autoConf=¿Está habilitada la confirmación automática?
 offerbook.buyXmrWith=Compra XMR con:
 offerbook.sellXmrFor=Vender XMR por:
 

--- a/core/src/main/resources/i18n/displayStrings_fa.properties
+++ b/core/src/main/resources/i18n/displayStrings_fa.properties
@@ -350,7 +350,7 @@ offerbook.timeSinceSigning.info.signer=signed by peer and can sign peer accounts
 offerbook.timeSinceSigning.info.banned=account was banned
 offerbook.timeSinceSigning.daysSinceSigning={0} روز
 offerbook.timeSinceSigning.daysSinceSigning.long={0} since signing
-offerbook.xmrAutoConf=Is auto-confirm enabled
+offerbook.autoConf=Is auto-confirm enabled
 offerbook.buyXmrWith=با XMR خرید کنید:
 offerbook.sellXmrFor=فروش XMR برای:
 

--- a/core/src/main/resources/i18n/displayStrings_fr.properties
+++ b/core/src/main/resources/i18n/displayStrings_fr.properties
@@ -350,7 +350,7 @@ offerbook.timeSinceSigning.info.signer=signé par un pair et pouvant signer des 
 offerbook.timeSinceSigning.info.banned=Ce compte a été banni
 offerbook.timeSinceSigning.daysSinceSigning={0} jours
 offerbook.timeSinceSigning.daysSinceSigning.long={0} depuis la signature
-offerbook.xmrAutoConf=Est-ce-que la confirmation automatique est activée
+offerbook.autoConf=Est-ce-que la confirmation automatique est activée
 offerbook.buyXmrWith=Acheter XMR avec :
 offerbook.sellXmrFor=Vendre XMR pour :
 

--- a/core/src/main/resources/i18n/displayStrings_it.properties
+++ b/core/src/main/resources/i18n/displayStrings_it.properties
@@ -350,7 +350,7 @@ offerbook.timeSinceSigning.info.signer=firmato da un peer e può firmare account
 offerbook.timeSinceSigning.info.banned= \nl'account è stato bannato
 offerbook.timeSinceSigning.daysSinceSigning={0} giorni
 offerbook.timeSinceSigning.daysSinceSigning.long={0} dalla firma
-offerbook.xmrAutoConf=Is auto-confirm enabled
+offerbook.autoConf=Is auto-confirm enabled
 offerbook.buyXmrWith=Compra XMR con:
 offerbook.sellXmrFor=Vendi XMR per:
 

--- a/core/src/main/resources/i18n/displayStrings_ja.properties
+++ b/core/src/main/resources/i18n/displayStrings_ja.properties
@@ -350,7 +350,7 @@ offerbook.timeSinceSigning.info.signer=ピアが署名しました。ピアア�
 offerbook.timeSinceSigning.info.banned=このアカウントは禁止されました
 offerbook.timeSinceSigning.daysSinceSigning={0}日
 offerbook.timeSinceSigning.daysSinceSigning.long=署名する後から {0}
-offerbook.xmrAutoConf=自動確認は有効されますか？
+offerbook.autoConf=自動確認は有効されますか？
 offerbook.buyXmrWith=XMRを購入:
 offerbook.sellXmrFor=XMRを売る:
 

--- a/core/src/main/resources/i18n/displayStrings_pt-br.properties
+++ b/core/src/main/resources/i18n/displayStrings_pt-br.properties
@@ -353,7 +353,7 @@ offerbook.timeSinceSigning.info.signer=assinada por um par e pode assinar contas
 offerbook.timeSinceSigning.info.banned=conta foi banida
 offerbook.timeSinceSigning.daysSinceSigning={0} dias
 offerbook.timeSinceSigning.daysSinceSigning.long={0} desde a assinatura
-offerbook.xmrAutoConf=Is auto-confirm enabled
+offerbook.autoConf=Is auto-confirm enabled
 offerbook.buyXmrWith=Compre XMR com:
 offerbook.sellXmrFor=Venda XMR por:
 

--- a/core/src/main/resources/i18n/displayStrings_pt.properties
+++ b/core/src/main/resources/i18n/displayStrings_pt.properties
@@ -350,7 +350,7 @@ offerbook.timeSinceSigning.info.signer=assinada por um par e pode assinar contas
 offerbook.timeSinceSigning.info.banned=account was banned
 offerbook.timeSinceSigning.daysSinceSigning={0} dias
 offerbook.timeSinceSigning.daysSinceSigning.long={0} desde a assinatura
-offerbook.xmrAutoConf=Is auto-confirm enabled
+offerbook.autoConf=Is auto-confirm enabled
 offerbook.buyXmrWith=Compre XMR com:
 offerbook.sellXmrFor=Venda XMR por:
 

--- a/core/src/main/resources/i18n/displayStrings_ru.properties
+++ b/core/src/main/resources/i18n/displayStrings_ru.properties
@@ -350,7 +350,7 @@ offerbook.timeSinceSigning.info.signer=signed by peer and can sign peer accounts
 offerbook.timeSinceSigning.info.banned=account was banned
 offerbook.timeSinceSigning.daysSinceSigning={0} дн.
 offerbook.timeSinceSigning.daysSinceSigning.long={0} since signing
-offerbook.xmrAutoConf=Is auto-confirm enabled
+offerbook.autoConf=Is auto-confirm enabled
 offerbook.buyXmrWith=Купить XMR с помощью:
 offerbook.sellXmrFor=Продать XMR за:
 

--- a/core/src/main/resources/i18n/displayStrings_th.properties
+++ b/core/src/main/resources/i18n/displayStrings_th.properties
@@ -350,7 +350,7 @@ offerbook.timeSinceSigning.info.signer=signed by peer and can sign peer accounts
 offerbook.timeSinceSigning.info.banned=account was banned
 offerbook.timeSinceSigning.daysSinceSigning={0} วัน
 offerbook.timeSinceSigning.daysSinceSigning.long={0} since signing
-offerbook.xmrAutoConf=Is auto-confirm enabled
+offerbook.autoConf=Is auto-confirm enabled
 offerbook.buyXmrWith=ซื้อ XMR ด้วย:
 offerbook.sellXmrFor=ขาย XMR สำหรับ:
 

--- a/core/src/main/resources/i18n/displayStrings_tr.properties
+++ b/core/src/main/resources/i18n/displayStrings_tr.properties
@@ -372,7 +372,7 @@ offerbook.timeSinceSigning.tooltip.info.signedAndLifted=Bu hesap imzalandı ve e
 offerbook.timeSinceSigning.tooltip.checkmark.buyXmr=imzalı bir hesaptan XMR al
 offerbook.timeSinceSigning.tooltip.checkmark.wait=minimal {0} gün bekleyin
 offerbook.timeSinceSigning.tooltip.learnMore=Daha fazla bilgi edin
-offerbook.xmrAutoConf=Otomatik onay etkin mi
+offerbook.autoConf=Otomatik onay etkin mi
 offerbook.buyXmrWith=XMR satın al:
 offerbook.sellXmrFor=XMR'i şunlar için satın:
 

--- a/core/src/main/resources/i18n/displayStrings_vi.properties
+++ b/core/src/main/resources/i18n/displayStrings_vi.properties
@@ -350,7 +350,7 @@ offerbook.timeSinceSigning.info.signer=signed by peer and can sign peer accounts
 offerbook.timeSinceSigning.info.banned=account was banned
 offerbook.timeSinceSigning.daysSinceSigning={0} ngày
 offerbook.timeSinceSigning.daysSinceSigning.long={0} since signing
-offerbook.xmrAutoConf=Is auto-confirm enabled
+offerbook.autoConf=Is auto-confirm enabled
 offerbook.buyXmrWith=Mua XMR với:
 offerbook.sellXmrFor=Bán XMR để:
 

--- a/core/src/main/resources/i18n/displayStrings_zh-hans.properties
+++ b/core/src/main/resources/i18n/displayStrings_zh-hans.properties
@@ -350,7 +350,7 @@ offerbook.timeSinceSigning.info.signer=由对方验证，并可验证对方账�
 offerbook.timeSinceSigning.info.banned=账户已被封禁
 offerbook.timeSinceSigning.daysSinceSigning={0} 天
 offerbook.timeSinceSigning.daysSinceSigning.long=自验证{0}
-offerbook.xmrAutoConf=是否开启自动确认
+offerbook.autoConf=是否开启自动确认
 offerbook.buyXmrWith=使用以下方式购买 XMR：
 offerbook.sellXmrFor=出售 XMR 以换取：
 

--- a/core/src/main/resources/i18n/displayStrings_zh-hant.properties
+++ b/core/src/main/resources/i18n/displayStrings_zh-hant.properties
@@ -350,7 +350,7 @@ offerbook.timeSinceSigning.info.signer=由對方驗證，並可驗證對方賬�
 offerbook.timeSinceSigning.info.banned=賬户已被封禁
 offerbook.timeSinceSigning.daysSinceSigning={0} 天
 offerbook.timeSinceSigning.daysSinceSigning.long=自驗證{0}
-offerbook.xmrAutoConf=是否開啟自動確認
+offerbook.autoConf=是否開啟自動確認
 offerbook.buyXmrWith=購買 XMR 使用：
 offerbook.sellXmrFor=出售 XMR 以換取：
 


### PR DESCRIPTION
## Summary
- support currency-specific auto-confirm keys instead of XMR-only key
- insert currency auto-confirm data when seller enables it
- switch translation strings to new `offerbook.autoConf` label

## Testing
- `./gradlew :core:test --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_689cb6564e8c8330a2b027ae102fad72