### PR TITLE
Add auto confirm services for multiple chains

### DIFF
--- a/core/src/main/java/haveno/core/autoconf/AutoConfirmService.java
+++ b/core/src/main/java/haveno/core/autoconf/AutoConfirmService.java
@@ -1,0 +1,27 @@
+package haveno.core.autoconf;
+
+import java.math.BigInteger;
+
+/**
+ * Service used to verify that a blockchain transaction has the expected
+ * receiver, amount and number of confirmations.
+ */
+public interface AutoConfirmService {
+
+    /**
+     * Verify that the transaction identified by {@code txId} pays {@code amount}
+     * to {@code receiverAddress} and has at least {@code requiredConfirmations} confirmations.
+     *
+     * @param txId the transaction identifier
+     * @param receiverAddress the expected recipient address
+     * @param amount expected amount in the chain's smallest unit
+     * @param requiredConfirmations minimum confirmations required
+     * @return {@code true} if the transaction satisfies all constraints
+     * @throws Exception if the underlying RPC call fails
+     */
+    boolean verify(String txId,
+                   String receiverAddress,
+                   BigInteger amount,
+                   int requiredConfirmations) throws Exception;
+}
+

--- a/core/src/main/java/haveno/core/autoconf/BitcoinAutoConfirmService.java
+++ b/core/src/main/java/haveno/core/autoconf/BitcoinAutoConfirmService.java
@@ -1,0 +1,83 @@
+package haveno.core.autoconf;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/**
+ * Implementation of {@link AutoConfirmService} for Bitcoin like chains using the
+ * JSON-RPC interface provided by Bitcoin Core and derivatives.
+ */
+public class BitcoinAutoConfirmService implements AutoConfirmService {
+
+    private final String rpcUrl;
+    private final String rpcUser;
+    private final String rpcPassword;
+
+    public BitcoinAutoConfirmService(String rpcUrl, String rpcUser, String rpcPassword) {
+        this.rpcUrl = rpcUrl;
+        this.rpcUser = rpcUser;
+        this.rpcPassword = rpcPassword;
+    }
+
+    @Override
+    public boolean verify(String txId, String receiverAddress, BigInteger amount, int requiredConfirmations) throws Exception {
+        JsonObject tx = rpc("gettransaction", txId).getAsJsonObject();
+        if (tx == null) return false;
+        JsonElement confEl = tx.get("confirmations");
+        if (confEl == null || confEl.getAsInt() < requiredConfirmations) return false;
+        JsonArray details = tx.getAsJsonArray("details");
+        if (details == null) return false;
+        for (JsonElement el : details) {
+            JsonObject det = el.getAsJsonObject();
+            if (receiverAddress.equals(det.get("address").getAsString())) {
+                BigDecimal value = det.get("amount").getAsBigDecimal();
+                BigInteger satoshis = value.movePointRight(8).toBigInteger();
+                if (satoshis.compareTo(amount) == 0) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    protected JsonObject rpc(String method, String param) throws Exception {
+        JsonArray params = new JsonArray();
+        if (param != null) params.add(param);
+        JsonObject req = new JsonObject();
+        req.addProperty("jsonrpc", "1.0");
+        req.addProperty("id", "autoconf");
+        req.addProperty("method", method);
+        req.add("params", params);
+
+        URL url = new URL(rpcUrl);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setDoOutput(true);
+        conn.setRequestMethod("POST");
+        String auth = Base64.getEncoder().encodeToString((rpcUser + ":" + rpcPassword).getBytes(StandardCharsets.UTF_8));
+        conn.setRequestProperty("Authorization", "Basic " + auth);
+        conn.setRequestProperty("Content-Type", "application/json");
+        try (OutputStream os = conn.getOutputStream()) {
+            os.write(req.toString().getBytes(StandardCharsets.UTF_8));
+        }
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
+            StringBuilder sb = new StringBuilder();
+            String line;
+            while ((line = br.readLine()) != null) sb.append(line);
+            JsonObject resp = new JsonParser().parse(sb.toString()).getAsJsonObject();
+            return resp.getAsJsonObject("result");
+        }
+    }
+}
+

--- a/core/src/main/java/haveno/core/autoconf/BitcoinCashAutoConfirmService.java
+++ b/core/src/main/java/haveno/core/autoconf/BitcoinCashAutoConfirmService.java
@@ -1,0 +1,14 @@
+package haveno.core.autoconf;
+
+/**
+ * Auto confirm service for Bitcoin Cash. Functionality is identical to
+ * {@link BitcoinAutoConfirmService} as Bitcoin Cash exposes the same JSON-RPC
+ * interface as Bitcoin Core.
+ */
+public class BitcoinCashAutoConfirmService extends BitcoinAutoConfirmService {
+
+    public BitcoinCashAutoConfirmService(String rpcUrl, String rpcUser, String rpcPassword) {
+        super(rpcUrl, rpcUser, rpcPassword);
+    }
+}
+

--- a/core/src/main/java/haveno/core/autoconf/EthereumAutoConfirmService.java
+++ b/core/src/main/java/haveno/core/autoconf/EthereumAutoConfirmService.java
@@ -1,0 +1,126 @@
+package haveno.core.autoconf;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.math.BigInteger;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Auto confirm service for Ethereum and ERC20 tokens using JSON-RPC.
+ */
+public class EthereumAutoConfirmService implements AutoConfirmService {
+
+    private static final String TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+    private final String rpcUrl;
+
+    public EthereumAutoConfirmService(String rpcUrl) {
+        this.rpcUrl = rpcUrl;
+    }
+
+    @Override
+    public boolean verify(String txId, String receiverAddress, BigInteger amount, int requiredConfirmations) throws Exception {
+        JsonObject tx = rpc("eth_getTransactionByHash", txId).getAsJsonObject();
+        if (tx == null) return false;
+        if (!receiverAddress.equalsIgnoreCase(tx.get("to").getAsString())) return false;
+        BigInteger value = new BigInteger(tx.get("value").getAsString().substring(2), 16);
+        if (!value.equals(amount)) return false;
+        BigInteger confirmations = getConfirmations(txId);
+        return confirmations.intValue() >= requiredConfirmations;
+    }
+
+    /**
+     * Verify an ERC20 token transfer.
+     */
+    public boolean verifyToken(String txId,
+                               String receiverAddress,
+                               BigInteger amount,
+                               int requiredConfirmations,
+                               String contractAddress,
+                               int expectedDecimals) throws Exception {
+        // verify contract exists
+        JsonElement code = rpc("eth_getCode", contractAddress, "latest");
+        if (code == null || code.getAsString().equals("0x")) return false;
+
+        // verify decimals
+        JsonObject callObj = new JsonObject();
+        callObj.addProperty("to", contractAddress);
+        callObj.addProperty("data", "0x313ce567"); // decimals()
+        JsonElement decimalsRes = rpc("eth_call", callObj, "latest");
+        if (decimalsRes == null) return false;
+        int decimals = new BigInteger(decimalsRes.getAsString().substring(2), 16).intValue();
+        if (decimals != expectedDecimals) return false;
+
+        // check transaction receipt logs
+        JsonObject receipt = rpc("eth_getTransactionReceipt", txId).getAsJsonObject();
+        if (receipt == null) return false;
+        BigInteger confirmations = getConfirmationsFromReceipt(receipt);
+        if (confirmations.intValue() < requiredConfirmations) return false;
+        JsonArray logs = receipt.getAsJsonArray("logs");
+        for (JsonElement el : logs) {
+            JsonObject log = el.getAsJsonObject();
+            if (!contractAddress.equalsIgnoreCase(log.get("address").getAsString())) continue;
+            JsonArray topics = log.getAsJsonArray("topics");
+            if (topics.size() < 3) continue;
+            if (!TRANSFER_TOPIC.equalsIgnoreCase(topics.get(0).getAsString())) continue;
+            String toTopic = topics.get(2).getAsString();
+            String to = "0x" + toTopic.substring(toTopic.length() - 40);
+            if (!to.equalsIgnoreCase(receiverAddress)) continue;
+            BigInteger value = new BigInteger(log.get("data").getAsString().substring(2), 16);
+            if (value.equals(amount)) return true;
+        }
+        return false;
+    }
+
+    private BigInteger getConfirmations(String txId) throws Exception {
+        JsonObject receipt = rpc("eth_getTransactionReceipt", txId).getAsJsonObject();
+        return getConfirmationsFromReceipt(receipt);
+    }
+
+    private BigInteger getConfirmationsFromReceipt(JsonObject receipt) throws Exception {
+        if (receipt == null || receipt.get("blockNumber").isJsonNull()) return BigInteger.ZERO;
+        BigInteger txBlock = new BigInteger(receipt.get("blockNumber").getAsString().substring(2), 16);
+        JsonElement latestBlockRes = rpc("eth_blockNumber");
+        BigInteger latest = new BigInteger(latestBlockRes.getAsString().substring(2), 16);
+        return latest.subtract(txBlock).add(BigInteger.ONE);
+    }
+
+    private JsonElement rpc(String method, Object... params) throws Exception {
+        JsonObject req = new JsonObject();
+        req.addProperty("jsonrpc", "2.0");
+        req.addProperty("id", 1);
+        req.addProperty("method", method);
+        JsonArray arr = new JsonArray();
+        for (Object p : params) {
+            if (p instanceof String) arr.add((String) p);
+            else if (p instanceof JsonElement) arr.add((JsonElement) p);
+            else if (p instanceof JsonObject) arr.add((JsonObject) p);
+        }
+        req.add("params", arr);
+
+        URL url = new URL(rpcUrl);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setDoOutput(true);
+        conn.setRequestMethod("POST");
+        conn.setRequestProperty("Content-Type", "application/json");
+        try (OutputStream os = conn.getOutputStream()) {
+            os.write(req.toString().getBytes(StandardCharsets.UTF_8));
+        }
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
+            StringBuilder sb = new StringBuilder();
+            String line;
+            while ((line = br.readLine()) != null) sb.append(line);
+            JsonObject resp = new JsonParser().parse(sb.toString()).getAsJsonObject();
+            return resp.get("result");
+        }
+    }
+}
+

--- a/core/src/main/java/haveno/core/autoconf/LitecoinAutoConfirmService.java
+++ b/core/src/main/java/haveno/core/autoconf/LitecoinAutoConfirmService.java
@@ -1,0 +1,13 @@
+package haveno.core.autoconf;
+
+/**
+ * Auto confirm service for Litecoin. Uses the same logic as
+ * {@link BitcoinAutoConfirmService}.
+ */
+public class LitecoinAutoConfirmService extends BitcoinAutoConfirmService {
+
+    public LitecoinAutoConfirmService(String rpcUrl, String rpcUser, String rpcPassword) {
+        super(rpcUrl, rpcUser, rpcPassword);
+    }
+}
+


### PR DESCRIPTION
## Summary
- introduce `AutoConfirmService` interface
- add RPC-backed auto confirm implementations for Bitcoin, Bitcoin Cash, Litecoin and Ethereum

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_689cbcab83208330ae891d9ae28ba678