### PR TITLE
Add auto-confirm crypto account type

### DIFF
--- a/core/src/main/java/haveno/core/payment/AutoConfirmCryptoAccount.java
+++ b/core/src/main/java/haveno/core/payment/AutoConfirmCryptoAccount.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.core.payment;
+
+import haveno.core.api.model.PaymentAccountFormField;
+import haveno.core.locale.CurrencyUtil;
+import haveno.core.locale.TradeCurrency;
+import haveno.core.payment.payload.InstantCryptoCurrencyPayload;
+import haveno.core.payment.payload.PaymentAccountPayload;
+import haveno.core.payment.payload.PaymentMethod;
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@EqualsAndHashCode(callSuper = true)
+public final class AutoConfirmCryptoAccount extends AssetAccount {
+
+    public static final List<TradeCurrency> SUPPORTED_CURRENCIES = new ArrayList<>(CurrencyUtil.getAllSortedCryptoCurrencies());
+
+    public AutoConfirmCryptoAccount() {
+        super(PaymentMethod.BLOCK_CHAINS_AUTOCONFIRM);
+    }
+
+    @Override
+    protected PaymentAccountPayload createPayload() {
+        return new InstantCryptoCurrencyPayload(paymentMethod.getId(), id);
+    }
+
+    @Override
+    public @NonNull List<TradeCurrency> getSupportedCurrencies() {
+        return SUPPORTED_CURRENCIES;
+    }
+
+    @Override
+    public @NonNull List<PaymentAccountFormField.FieldId> getInputFieldIds() {
+        throw new RuntimeException("Not implemented");
+    }
+}

--- a/core/src/main/java/haveno/core/payment/PaymentAccountFactory.java
+++ b/core/src/main/java/haveno/core/payment/PaymentAccountFactory.java
@@ -112,6 +112,8 @@ public class PaymentAccountFactory {
                 return new AmazonGiftCardAccount();
             case PaymentMethod.BLOCK_CHAINS_INSTANT_ID:
                 return new InstantCryptoCurrencyAccount();
+            case PaymentMethod.BLOCK_CHAINS_AUTOCONFIRM_ID:
+                return new AutoConfirmCryptoAccount();
             case PaymentMethod.CAPITUAL_ID:
                 return new CapitualAccount();
             case PaymentMethod.CELPAY_ID:

--- a/core/src/main/java/haveno/core/payment/PaymentAccountUtil.java
+++ b/core/src/main/java/haveno/core/payment/PaymentAccountUtil.java
@@ -45,6 +45,7 @@ import static haveno.core.payment.payload.PaymentMethod.AUSTRALIA_PAYID_ID;
 import static haveno.core.payment.payload.PaymentMethod.BIZUM_ID;
 import static haveno.core.payment.payload.PaymentMethod.BLOCK_CHAINS;
 import static haveno.core.payment.payload.PaymentMethod.BLOCK_CHAINS_INSTANT;
+import static haveno.core.payment.payload.PaymentMethod.BLOCK_CHAINS_AUTOCONFIRM;
 import static haveno.core.payment.payload.PaymentMethod.CAPITUAL_ID;
 import static haveno.core.payment.payload.PaymentMethod.CASH_APP_ID;
 import static haveno.core.payment.payload.PaymentMethod.PAY_BY_MAIL_ID;
@@ -308,7 +309,8 @@ public class PaymentAccountUtil {
 
     public static boolean isCryptoCurrencyAccount(PaymentAccount paymentAccount) {
         return (paymentAccount != null && paymentAccount.getPaymentMethod().equals(BLOCK_CHAINS) ||
-                paymentAccount != null && paymentAccount.getPaymentMethod().equals(BLOCK_CHAINS_INSTANT));
+                paymentAccount != null && paymentAccount.getPaymentMethod().equals(BLOCK_CHAINS_INSTANT) ||
+                paymentAccount != null && paymentAccount.getPaymentMethod().equals(BLOCK_CHAINS_AUTOCONFIRM));
     }
 
     public static Optional<PaymentAccount> findPaymentAccount(PaymentAccountPayload paymentAccountPayload,

--- a/core/src/main/java/haveno/core/payment/payload/PaymentMethod.java
+++ b/core/src/main/java/haveno/core/payment/payload/PaymentMethod.java
@@ -177,6 +177,7 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
     public static final String PIX_ID = "PIX";
     public static final String AMAZON_GIFT_CARD_ID = "AMAZON_GIFT_CARD";
     public static final String BLOCK_CHAINS_INSTANT_ID = "BLOCK_CHAINS_INSTANT";
+    public static final String BLOCK_CHAINS_AUTOCONFIRM_ID = "BLOCK_CHAINS_AUTOCONFIRM";
     public static final String PAY_BY_MAIL_ID = "PAY_BY_MAIL";
     public static final String CASH_AT_ATM_ID = "CASH_AT_ATM";
     public static final String CAPITUAL_ID = "CAPITUAL";
@@ -238,6 +239,7 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
     public static PaymentMethod PIX;
     public static PaymentMethod AMAZON_GIFT_CARD;
     public static PaymentMethod BLOCK_CHAINS_INSTANT;
+    public static PaymentMethod BLOCK_CHAINS_AUTOCONFIRM;
     public static PaymentMethod PAY_BY_MAIL;
     public static PaymentMethod CASH_AT_ATM;
     public static PaymentMethod CAPITUAL;
@@ -342,9 +344,10 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
 
             // Cryptos
             BLOCK_CHAINS = new PaymentMethod(BLOCK_CHAINS_ID, DAY, DEFAULT_TRADE_LIMIT_CRYPTO, Arrays.asList()),
-            
+
             // Cryptos with 1 hour trade period
-            BLOCK_CHAINS_INSTANT = new PaymentMethod(BLOCK_CHAINS_INSTANT_ID, TimeUnit.HOURS.toMillis(1), DEFAULT_TRADE_LIMIT_CRYPTO, Arrays.asList())
+            BLOCK_CHAINS_INSTANT = new PaymentMethod(BLOCK_CHAINS_INSTANT_ID, TimeUnit.HOURS.toMillis(1), DEFAULT_TRADE_LIMIT_CRYPTO, Arrays.asList()),
+            BLOCK_CHAINS_AUTOCONFIRM = new PaymentMethod(BLOCK_CHAINS_AUTOCONFIRM_ID, TimeUnit.HOURS.toMillis(1), DEFAULT_TRADE_LIMIT_CRYPTO, Arrays.asList())
     );
 
     // TODO: delete this override method, which overrides the paymentMethods variable, when all payment methods supported using structured form api, and make paymentMethods private
@@ -551,7 +554,7 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
     }
 
     public boolean isBlockchain() {
-        return this.equals(BLOCK_CHAINS_INSTANT) || this.equals(BLOCK_CHAINS);
+        return this.equals(BLOCK_CHAINS_INSTANT) || this.equals(BLOCK_CHAINS_AUTOCONFIRM) || this.equals(BLOCK_CHAINS);
     }
 
     // Includes any non btc asset, not limited to blockchain payment methods

--- a/core/src/main/java/haveno/core/trade/statistics/TradeStatistics3.java
+++ b/core/src/main/java/haveno/core/trade/statistics/TradeStatistics3.java
@@ -215,7 +215,8 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
         TRANSFERWISE_USD,
         ACH_TRANSFER,
         DOMESTIC_WIRE_TRANSFER,
-        PAYPAL
+        PAYPAL,
+        BLOCK_CHAINS_AUTOCONFIRM
     }
 
     @Getter

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -3219,6 +3219,8 @@ AMAZON_GIFT_CARD=Amazon eGift Card
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT=Cryptocurrencies Instant
 # suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM=Cryptocurrencies Auto-Confirm
+# suppress inspection "UnusedProperty"
 CAPITUAL=Capitual
 # suppress inspection "UnusedProperty"
 CELPAY=CelPay
@@ -3316,6 +3318,8 @@ PIX_SHORT=Pix
 AMAZON_GIFT_CARD_SHORT=Amazon eGift Card
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT_SHORT=Cryptocurrencies Instant
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM_SHORT=Cryptocurrencies Auto-Confirm
 # suppress inspection "UnusedProperty"
 CAPITUAL_SHORT=Capitual
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_cs.properties
+++ b/core/src/main/resources/i18n/displayStrings_cs.properties
@@ -3169,6 +3169,8 @@ AMAZON_GIFT_CARD=Amazon eGift Card
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT=Kryptoměny okamžité
 # suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM=Kryptoměny Auto-Confirm
+# suppress inspection "UnusedProperty"
 CAPITUAL=Capitual
 # suppress inspection "UnusedProperty"
 CELPAY=CelPay
@@ -3264,6 +3266,8 @@ PIX_SHORT=Pix
 AMAZON_GIFT_CARD_SHORT=Amazon eGift Card
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT_SHORT=Kryptoměny okamžité
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM_SHORT=Kryptoměny Auto-Confirm
 # suppress inspection "UnusedProperty"
 CAPITUAL_SHORT=Capitual
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_de.properties
+++ b/core/src/main/resources/i18n/displayStrings_de.properties
@@ -2140,6 +2140,8 @@ TRANSFERWISE=Wise
 AMAZON_GIFT_CARD=Amazon Gift-Karte
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT=Cryptos schnell
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM=Cryptos Autoconfirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"
@@ -2192,6 +2194,8 @@ TRANSFERWISE_SHORT=Wise
 AMAZON_GIFT_CARD_SHORT=Amazon Gift-Karte
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT_SHORT=Cryptos schnell
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM_SHORT=Cryptos Autoconfirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_es.properties
+++ b/core/src/main/resources/i18n/displayStrings_es.properties
@@ -2141,6 +2141,8 @@ TRANSFERWISE=Wise
 AMAZON_GIFT_CARD=Tarjeta Amazon eGift
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT=Cryptos instant
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM=Cryptos Auto-Confirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"
@@ -2193,6 +2195,8 @@ TRANSFERWISE_SHORT=Wise
 AMAZON_GIFT_CARD_SHORT=Tarjeta Amazon eGift
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT_SHORT=Cryptos instant
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM_SHORT=Cryptos Auto-Confirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_fa.properties
+++ b/core/src/main/resources/i18n/displayStrings_fa.properties
@@ -2112,6 +2112,8 @@ TRANSFERWISE=Wise
 AMAZON_GIFT_CARD=Amazon eGift Card
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT=Cryptos Instant
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM=Cryptos Auto-Confirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"
@@ -2164,6 +2166,8 @@ TRANSFERWISE_SHORT=Wise
 AMAZON_GIFT_CARD_SHORT=Amazon eGift Card
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT_SHORT=Cryptos Instant
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM_SHORT=Cryptos Auto-Confirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_fr.properties
+++ b/core/src/main/resources/i18n/displayStrings_fr.properties
@@ -2144,6 +2144,8 @@ TRANSFERWISE=Wise
 AMAZON_GIFT_CARD=eCarte cadeau Amazon
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT=Cryptos Instant
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM=Cryptos Auto-Confirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"
@@ -2196,6 +2198,8 @@ TRANSFERWISE_SHORT=Wise
 AMAZON_GIFT_CARD_SHORT=eCarte cadeau Amazon
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT_SHORT=Cryptos Instant
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM_SHORT=Cryptos Auto-Confirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_it.properties
+++ b/core/src/main/resources/i18n/displayStrings_it.properties
@@ -2115,6 +2115,8 @@ TRANSFERWISE=Wise
 AMAZON_GIFT_CARD=Amazon eGift Card
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT=Crypto Instant
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM=Crypto Auto-Confirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"
@@ -2167,6 +2169,8 @@ TRANSFERWISE_SHORT=Wise
 AMAZON_GIFT_CARD_SHORT=Amazon eGift Card
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT_SHORT=Crypto Instant
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM_SHORT=Crypto Auto-Confirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_ja.properties
+++ b/core/src/main/resources/i18n/displayStrings_ja.properties
@@ -2140,6 +2140,8 @@ TRANSFERWISE=Wise
 AMAZON_GIFT_CARD=アマゾンeGiftカード
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT=アルトコイン インスタント
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM=アルトコイン Auto-Confirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"
@@ -2192,6 +2194,8 @@ TRANSFERWISE_SHORT=Wise
 AMAZON_GIFT_CARD_SHORT=アマゾンeGiftカード
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT_SHORT=アルトコイン インスタント
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM_SHORT=アルトコイン Auto-Confirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_pt-br.properties
+++ b/core/src/main/resources/i18n/displayStrings_pt-br.properties
@@ -2122,6 +2122,8 @@ TRANSFERWISE=Wise
 AMAZON_GIFT_CARD=Amazon eGift Card
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT=Instant Cryptos
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM=Cryptos Auto-Confirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"
@@ -2174,6 +2176,8 @@ TRANSFERWISE_SHORT=Wise
 AMAZON_GIFT_CARD_SHORT=Amazon eGift Card
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT_SHORT=Cryptos Instant
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM_SHORT=Cryptos Auto-Confirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_pt.properties
+++ b/core/src/main/resources/i18n/displayStrings_pt.properties
@@ -2112,6 +2112,8 @@ TRANSFERWISE=Wise
 AMAZON_GIFT_CARD=Amazon eGift Card
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT=Cryptos Instantâneas
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM=Cryptos Auto-Confirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"
@@ -2164,6 +2166,8 @@ TRANSFERWISE_SHORT=Wise
 AMAZON_GIFT_CARD_SHORT=Amazon eGift Card
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT_SHORT=Cryptos Instant
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM_SHORT=Cryptos Auto-Confirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_ru.properties
+++ b/core/src/main/resources/i18n/displayStrings_ru.properties
@@ -2114,6 +2114,8 @@ TRANSFERWISE=Wise
 AMAZON_GIFT_CARD=Amazon eGift Card
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT=Альткойны (мгновенно)
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM=Альткойны Auto-Confirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"
@@ -2166,6 +2168,8 @@ TRANSFERWISE_SHORT=Wise
 AMAZON_GIFT_CARD_SHORT=Amazon eGift Card
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT_SHORT=Альткойны (мгновенно)
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM_SHORT=Альткойны Auto-Confirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_th.properties
+++ b/core/src/main/resources/i18n/displayStrings_th.properties
@@ -2113,6 +2113,8 @@ TRANSFERWISE=Wise
 AMAZON_GIFT_CARD=Amazon eGift Card
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT=Cryptos Instant
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM=Cryptos Auto-Confirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"
@@ -2165,6 +2167,8 @@ TRANSFERWISE_SHORT=Wise
 AMAZON_GIFT_CARD_SHORT=Amazon eGift Card
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT_SHORT=Cryptos Instant
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM_SHORT=Cryptos Auto-Confirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_tr.properties
+++ b/core/src/main/resources/i18n/displayStrings_tr.properties
@@ -3156,6 +3156,8 @@ AMAZON_GIFT_CARD=Amazon Hediye Kartı
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT=Anında Kripto Para
 # suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM=Kripto Para Auto-Confirm
+# suppress inspection "UnusedProperty"
 CAPITUAL=Capitual
 # suppress inspection "UnusedProperty"
 CELPAY=CelPay
@@ -3251,6 +3253,8 @@ PIX_SHORT=Pix
 AMAZON_GIFT_CARD_SHORT=Amazon Hediye Kartı
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT_SHORT=Anında Kripto Para
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM_SHORT=Kripto Para Auto-Confirm
 # suppress inspection "UnusedProperty"
 CAPITUAL_SHORT=Capitual
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_vi.properties
+++ b/core/src/main/resources/i18n/displayStrings_vi.properties
@@ -2115,6 +2115,8 @@ TRANSFERWISE=Wise
 AMAZON_GIFT_CARD=Amazon eGift Card
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT=Crypto ngay tức thì
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM=Crypto Auto-Confirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"
@@ -2167,6 +2169,8 @@ TRANSFERWISE_SHORT=Wise
 AMAZON_GIFT_CARD_SHORT=Amazon eGift Card
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT_SHORT=Crypto ngay tức thì
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM_SHORT=Crypto Auto-Confirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_zh-hans.properties
+++ b/core/src/main/resources/i18n/displayStrings_zh-hans.properties
@@ -2125,6 +2125,8 @@ TRANSFERWISE=Wise
 AMAZON_GIFT_CARD=亚马逊电子礼品卡
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT=Cryptos Instant
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM=Cryptos Auto-Confirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"
@@ -2177,6 +2179,8 @@ TRANSFERWISE_SHORT=Wise
 AMAZON_GIFT_CARD_SHORT=亚马逊电子礼品卡
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT_SHORT=Cryptos Instant
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM_SHORT=Cryptos Auto-Confirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_zh-hant.properties
+++ b/core/src/main/resources/i18n/displayStrings_zh-hant.properties
@@ -2119,6 +2119,8 @@ TRANSFERWISE=Wise
 AMAZON_GIFT_CARD=亞馬遜電子禮品卡
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT=Cryptos Instant
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM=Cryptos Auto-Confirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"
@@ -2171,6 +2173,8 @@ TRANSFERWISE_SHORT=Wise
 AMAZON_GIFT_CARD_SHORT=亞馬遜電子禮品卡
 # suppress inspection "UnusedProperty"
 BLOCK_CHAINS_INSTANT_SHORT=Cryptos Instant
+# suppress inspection "UnusedProperty"
+BLOCK_CHAINS_AUTOCONFIRM_SHORT=Cryptos Auto-Confirm
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"

--- a/desktop/src/main/java/haveno/desktop/main/offer/offerbook/OfferBookViewModel.java
+++ b/desktop/src/main/java/haveno/desktop/main/offer/offerbook/OfferBookViewModel.java
@@ -697,7 +697,8 @@ abstract class OfferBookViewModel extends ActivatableViewModel {
     }
 
     public boolean isInstantPaymentMethod(Offer offer) {
-        return offer.getPaymentMethod().equals(PaymentMethod.BLOCK_CHAINS_INSTANT);
+        return offer.getPaymentMethod().equals(PaymentMethod.BLOCK_CHAINS_INSTANT) ||
+               offer.getPaymentMethod().equals(PaymentMethod.BLOCK_CHAINS_AUTOCONFIRM);
     }
 
     public void setOfferActionHandler(OfferView.OfferActionHandler offerActionHandler) {

--- a/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
+++ b/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
@@ -331,6 +331,7 @@ public class BuyerStep2View extends TradeStepView {
                 break;
             case PaymentMethod.BLOCK_CHAINS_ID:
             case PaymentMethod.BLOCK_CHAINS_INSTANT_ID:
+            case PaymentMethod.BLOCK_CHAINS_AUTOCONFIRM_ID:
                 String labelTitle = Res.get("portfolio.pending.step2_buyer.sellersAddress", getCurrencyName(trade));
                 gridRow = AssetsForm.addFormForBuyer(gridPane, gridRow, paymentAccountPayload, labelTitle);
                 break;


### PR DESCRIPTION
## Summary
- Add AutoConfirmCryptoAccount mirroring the instant crypto account
- Introduce new PaymentMethod `BLOCK_CHAINS_AUTOCONFIRM` and support logic
- Localize and register auto-confirm crypto account across UI

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_689cc4740ae483308a9f398c2701fb26