### PR TITLE
Add Ethereum auto-confirm validation and reuse warnings

### DIFF
--- a/core/src/main/java/haveno/core/ethereum/EthereumAutoConfirmService.java
+++ b/core/src/main/java/haveno/core/ethereum/EthereumAutoConfirmService.java
@@ -1,0 +1,96 @@
+package haveno.core.ethereum;
+
+import haveno.core.user.Preferences;
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Service to auto-confirm Ethereum based transfers.
+ *
+ * <p>This implementation keeps a cache of confirmed transaction hashes in order to
+ * detect address or transaction reuse. When a reuse is detected the configured
+ * {@link Preferences} instance is notified so the UI can warn the user.</p>
+ */
+public class EthereumAutoConfirmService {
+
+    /**
+     * Simple container for token metadata.
+     */
+    private static class TokenMetadata {
+        final String name;
+        final String symbol;
+
+        TokenMetadata(String name, String symbol) {
+            this.name = name;
+            this.symbol = symbol;
+        }
+    }
+
+    // Known ERC20 token contracts and their metadata.
+    private static final Map<String, TokenMetadata> KNOWN_TOKENS = Map.of(
+            // DAI Stablecoin
+            "0x6b175474e89094c44da98b954eedeac495271d0f", new TokenMetadata("Dai Stablecoin", "DAI-ERC20"),
+            // USD Coin
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", new TokenMetadata("USD Coin", "USDC"),
+            // Tether USD
+            "0xdac17f958d2ee523a2206206994597c13d831ec7", new TokenMetadata("Tether USD", "USDT"),
+            // TrueUSD
+            "0x0000000000085d4780b73119b644ae5ecd22b376", new TokenMetadata("TrueUSD", "TUSD")
+    );
+
+    private final Set<String> confirmedTxs = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private final Preferences preferences;
+
+    public EthereumAutoConfirmService(Preferences preferences) {
+        this.preferences = preferences;
+    }
+
+    /**
+     * Verify that a provided contract address exists and matches known token metadata.
+     *
+     * @param contractAddress the ERC20 contract address
+     * @param tokenName       the token's name supplied by the user
+     * @param tokenSymbol     the token's symbol supplied by the user
+     * @return {@code true} if the contract is recognised and matches the expected metadata
+     */
+    public boolean verifyContractAddress(String contractAddress, String tokenName, String tokenSymbol) {
+        if (contractAddress == null) return false;
+        TokenMetadata meta = KNOWN_TOKENS.get(contractAddress.toLowerCase());
+        return meta != null && meta.name.equals(tokenName) && meta.symbol.equals(tokenSymbol);
+    }
+
+    /**
+     * Validate that a transfer amount matches the trade amount and that the required
+     * confirmations have been met.
+     *
+     * @param transferAmount       amount transferred in smallest units
+     * @param tradeAmount          amount expected for the trade in smallest units
+     * @param confirmations        number of confirmations the transaction has
+     * @param requiredConfirmations number of confirmations required
+     * @return {@code true} if the amounts match and confirmations are sufficient
+     */
+    public boolean validateTransaction(BigInteger transferAmount, BigInteger tradeAmount, int confirmations, int requiredConfirmations) {
+        return transferAmount != null && transferAmount.equals(tradeAmount) && confirmations >= requiredConfirmations;
+    }
+
+    /**
+     * Track confirmed transaction hashes and detect reuse. If a transaction hash is
+     * seen more than once the user is warned via {@link Preferences}.
+     *
+     * @param txHash the transaction hash to test
+     * @return {@code true} if the transaction hash has been seen before
+     */
+    public boolean isTxHashReused(String txHash) {
+        if (txHash == null) return false;
+        if (confirmedTxs.contains(txHash)) {
+            preferences.setAddressReuseDetected(true);
+            return true;
+        }
+        confirmedTxs.add(txHash);
+        return false;
+    }
+}
+

--- a/core/src/main/java/haveno/core/user/Preferences.java
+++ b/core/src/main/java/haveno/core/user/Preferences.java
@@ -137,6 +137,8 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
     private final BooleanProperty useStandbyModeProperty = new SimpleBooleanProperty(prefPayload.isUseStandbyMode());
     @Getter
     private final BooleanProperty useSoundForNotificationsProperty = new SimpleBooleanProperty(prefPayload.isUseSoundForNotifications());
+    @Getter
+    private final BooleanProperty addressReuseDetectedProperty = new SimpleBooleanProperty(false);
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
@@ -739,6 +741,10 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
 
     public void setUseSoundForNotifications(boolean useSoundForNotifications) {
         this.useSoundForNotificationsProperty.set(useSoundForNotifications);
+    }
+
+    public void setAddressReuseDetected(boolean detected) {
+        this.addressReuseDetectedProperty.set(detected);
     }
 
     public void setTakeOfferSelectedPaymentAccountId(String value) {

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -3432,3 +3432,6 @@ validation.phone.invalidDialingCode=Country dialing code for number {0} is inval
 validation.invalidAddressList=Must be comma separated list of valid addresses
 validation.capitual.invalidFormat=Must be a valid CAP code of format: CAP-XXXXXX (6 alphanumeric characters)
 
+
+setting.addressReuse.headline=Address or transaction reused
+setting.addressReuse.msg=The address or transaction hash has been used before. Please generate a new address and send a fresh transaction to protect your privacy.

--- a/desktop/src/main/java/haveno/desktop/main/settings/preferences/PreferencesView.java
+++ b/desktop/src/main/java/haveno/desktop/main/settings/preferences/PreferencesView.java
@@ -180,6 +180,12 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         initializeSeparator();
         initializeAutoConfirmOptions();
         initializeDisplayCurrencies();
+
+        preferences.getAddressReuseDetectedProperty().addListener((obs, oldVal, newVal) -> {
+            if (newVal) {
+                showAddressReusePopup();
+            }
+        });
     }
 
 
@@ -514,6 +520,15 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         });
 
         displayCurrenciesGridRowIndex += listRowSpan;
+    }
+
+    private void showAddressReusePopup() {
+        new Popup()
+                .headLine(Res.get("setting.addressReuse.headline"))
+                .backgroundInfo(Res.get("setting.addressReuse.msg"))
+                .actionButtonText(Res.get("shared.ok"))
+                .onAction(() -> preferences.setAddressReuseDetected(false))
+                .show();
     }
 
     private void initializeDisplayOptions() {


### PR DESCRIPTION
## Summary
- validate ERC20 contract addresses against known token metadata
- check transfer amounts and confirmations during Ethereum auto-confirm
- cache confirmed tx hashes and warn on reuse with Preferences popup

## Testing
- `./gradlew :core:test :desktop:test`

------
https://chatgpt.com/codex/tasks/task_e_689cc478102883309babc88b7f38dca3